### PR TITLE
Created .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+# Scilab generates these by itself upon running builder.sce
+cleaner.sce
+loader.sce
+unloader.sce
+*.bin
+
+# Libraries
+lib*.c
+*.so
+
+# Temporary files
+*~
+*.swp
+
+# Other
+*.pdf
+*.gz


### PR DESCRIPTION
This will prevent compiled binaries from being uploaded to the repo. Only code will be uploaded to the repo.
However, this may require the user to use builder.sce to compile the library first and then loader.sce
